### PR TITLE
Changing on_weekday? logic

### DIFF
--- a/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
+++ b/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb
@@ -55,7 +55,7 @@ module DateAndTime
 
     # Returns true if the date/time does not fall on a Saturday or Sunday.
     def on_weekday?
-      !WEEKEND_DAYS.include?(wday)
+      !on_weekend?
     end
 
     # Returns a new date/time the specified number of days ago.


### PR DESCRIPTION
### Summary

There's no need duplicate the logic in this method. Simply calling !on_weekend? will work.


